### PR TITLE
Fix open register ID sync

### DIFF
--- a/src/pages/dashboard/Sales.jsx
+++ b/src/pages/dashboard/Sales.jsx
@@ -72,6 +72,13 @@ const Sales = () => {
     setValue('invoice.total_amount', totalAmount);
   }, [invoiceItems, setValue]);
 
+  // Efecto para actualizar el id de la caja abierta cuando cambie
+  useEffect(() => {
+    if (openRegister && openRegister.id) {
+      setValue('open_register_id', openRegister.id);
+    }
+  }, [openRegister, setValue]);
+
   useEffect(() => {
     const fetchPrevisions = async () => {
       const response = await getPrevisions();


### PR DESCRIPTION
## Summary
- sync open register ID with form whenever the active register changes

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_6859c66f391c832eb8da0d95999b9087