### PR TITLE
Update bono validation

### DIFF
--- a/src/pages/dashboard/Sales.jsx
+++ b/src/pages/dashboard/Sales.jsx
@@ -55,6 +55,7 @@ const Sales = () => {
       description: '',
       transaction_type_id: "e66064ea-fd72-49da-8503-95412af64f33", // ID fijo para ventas
       payment_method_id: '',
+      is_bono: false,
       folio: '',
       invoice: {
         custumer_nid: '',
@@ -143,9 +144,10 @@ const Sales = () => {
 
   const onSubmit = async (data) => {
     try {
+      const { is_bono, ...payload } = data;
 
-      console.log('Formulario enviado:', data);
-      const response = await createTransaction(data);
+      console.log('Formulario enviado:', payload);
+      const response = await createTransaction(payload);
       console.log('Respuesta del servidor:', response);
       
       if (response.status === 201) {
@@ -179,7 +181,9 @@ const Sales = () => {
 
   const handlePaymentMethodChange = (e) => {
     const selectedMethod = paymentMethods.find(method => method.id === e.target.value);
-    setShowFolioInput(selectedMethod?.description?.toLowerCase().includes('bono'));
+    const isBono = selectedMethod?.description?.toLowerCase().includes('bono');
+    setShowFolioInput(isBono);
+    setValue('is_bono', isBono);
   };
 
   return (

--- a/src/utils/transactionSchema.js
+++ b/src/utils/transactionSchema.js
@@ -21,6 +21,8 @@ export const transactionSchema = z.object({
   description: z.string().min(1, 'La descripción es requerida'),
   transaction_type_id: z.string().min(1, 'El tipo de transacción es requerido'),
   payment_method_id: z.string().min(1, 'El método de pago es requerido'),
+  // Bandera interna para determinar si el método de pago exige folio
+  is_bono: z.boolean().optional(),
   folio: z.string().optional().refine((val) => {
     if (!val) return true; // Si no hay valor, la validación pasa
     return /^\d+$/.test(val); // Si hay valor, debe ser solo números
@@ -28,15 +30,11 @@ export const transactionSchema = z.object({
   invoice: invoiceSchema
 }).refine((data) => {
   // Si el método de pago es un bono, el folio es requerido
-  const isBono = data.payment_method_id && 
-    (data.payment_method_id.toLowerCase().includes('bono papel') || 
-     data.payment_method_id.toLowerCase().includes('bono electronico'));
-  
-  if (isBono) {
+  if (data.is_bono) {
     return !!data.folio;
   }
   return true;
 }, {
   message: "El número de folio es requerido para bonos",
   path: ["folio"]
-}); 
+});


### PR DESCRIPTION
## Summary
- add `is_bono` flag to sales form
- validate folio requirement based on new flag
- keep extra field out of request payload

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6859c66e4d30832ea64ecb7c55c3303d