### PR TITLE
feat(ui): reports & admin visual restyle — Reports + CloseRegister + CancelTransactions (PR 6 of 8)

### DIFF
--- a/docs/COMPONENT_INVENTORY.md
+++ b/docs/COMPONENT_INVENTORY.md
@@ -235,26 +235,66 @@ All sales page components now use **semantic design tokens only**:
 
 ---
 
+## PR 6 — Reports & Admin Pages Visual Restyle
+
+### Token Discipline
+
+All reports and admin page components now use **semantic design tokens only**:
+- `neutral-*` for text, borders, and backgrounds (replaces raw `gray-*`/`slate-*`)
+- `primary-*` for brand accents and icons
+- `secondary-*` for CloseRegister summary tiles
+- `error-*` for validation errors and destructive actions (replaces raw `red-*`)
+- `warning-*` for devolution and discrepancy highlights (replaces raw `yellow-*`)
+- `info-*` for informational tiles (replaces raw `purple-*`)
+- Zero raw `bg-(gray|slate|zinc|neutral|teal|emerald)-[0-9]` in page code
+- Solid shades used instead of opacity modifiers (Tailwind CSS var limitation)
+- Dark mode parity via `neutral-700`/`neutral-800`/`neutral-900`
+
+### Accessibility
+
+- All inputs have `aria-invalid` and `aria-describedby` linked to error messages
+- Error messages use `role="alert"` for screen reader announcements
+- All interactive elements have visible focus rings (`focus:ring-2 focus:ring-primary-*`)
+
+### Files Restyled
+
+| File | Token Changes | A11y Enhancements |
+|------|--------------|-------------------|
+| `src/pages/dashboard/Reports.jsx` | neutral bg/border/text tokens | — |
+| `src/components/Reports/ReportFilters.jsx` | neutral bg/border tokens, error tokens | role="alert" on validation |
+| `src/components/Reports/ReportViewer.jsx` | neutral border/text tokens | — |
+| `src/pages/dashboard/CloseRegister.jsx` | neutral bg/border tokens | — |
+| `src/pages/dashboard/close/CloseHeader.jsx` | neutral text tokens | — |
+| `src/components/CloseRegister/ReconciliationSummaryCard.jsx` | neutral/secondary/primary/info tokens, solid shades | — |
+| `src/components/CloseRegister/AmountInputCard.jsx` | neutral/error tokens | role="alert" on field errors |
+| `src/components/CloseRegister/ApprovalModal.jsx` | neutral/warning/secondary tokens, solid shades | — |
+| `src/pages/dashboard/CancelTransactions.jsx` | neutral bg/border tokens | — |
+| `src/pages/dashboard/cancel/CancelHeader.jsx` | neutral text tokens | — |
+| `src/pages/dashboard/cancel/CancelFilters.jsx` | neutral text/icon tokens | — |
+| `src/pages/dashboard/cancel/CancelList.jsx` | neutral text/bg tokens | — |
+| `src/components/CancelTransactions/CancelConfirmModal.jsx` | neutral/error tokens, solid shades | — |
+| `src/components/CancelTransactions/DevolutionConfirmModal.jsx` | neutral/warning tokens, solid shades | — |
+
+---
+
 ## Summary
 
 ### Decomposition Stats
 
-| Metric | PR 2A | PR 2B | PR 3 | PR 4 | PR 5 | Total |
-|--------|-------|-------|------|------|------|-------|
-| Pages decomposed | 4 | 4 | 2 (migrated) | — | — | 8 |
-| Pages restyled | — | — | — | 2 + layouts | 12 sales components | 2 + 8 layouts + 12 sales |
-| New files created | 18 | 9 | 3 | 0 | 0 | 30 |
-| Total new lines | ~1,200 | ~800 | ~310 | ~265 (restyle) | ~107 (restyle) | ~2,682 |
-| Max page size (before) | 494 | 331 | 146 | 62 | 73 | 494 |
-| Max page size (after) | 97 | 131 | 148 | 62 | 73 | 73 |
-| All files ≤200 lines | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
-| Forms using RHF+Zod | 2 (Login, Register) | 0 | 2 (OpenRegister, CloseRegister) | — | — | 4 |
-| Token-compliant pages | — | — | — | ✅ All auth | ✅ All sales | ✅ Auth + Sales |
+| Metric | PR 2A | PR 2B | PR 3 | PR 4 | PR 5 | PR 6 | Total |
+|--------|-------|-------|------|------|------|------|-------|
+| Pages decomposed | 4 | 4 | 2 (migrated) | — | — | — | 8 |
+| Pages restyled | — | — | — | 2 + layouts | 12 sales | 14 admin/reports | 2 + 8 layouts + 12 sales + 14 admin |
+| New files created | 18 | 9 | 3 | 0 | 0 | 0 | 30 |
+| Total new lines | ~1,200 | ~800 | ~310 | ~265 (restyle) | ~107 (restyle) | ~129 (restyle) | ~2,811 |
+| Max page size (before) | 494 | 331 | 146 | 62 | 73 | 131 | 494 |
+| Max page size (after) | 97 | 131 | 148 | 62 | 73 | 131 | 73 |
+| All files ≤200 lines | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| Forms using RHF+Zod | 2 (Login, Register) | 0 | 2 (OpenRegister, CloseRegister) | — | — | — | 4 |
+| Token-compliant pages | — | — | — | ✅ All auth | ✅ All sales | ✅ All admin/reports | ✅ Auth + Sales + Admin |
 
 ### Next Steps
 
-- **PR 5**: Sales pages visual redesign
-- **PR 6**: Reports & admin visual redesign
 - **PR 7**: Cross-cutting polish (skeletons, error boundaries, empty states, a11y)
 
 ### Verification Commands
@@ -275,5 +315,5 @@ pnpm build
 
 ---
 
-**Last updated**: PR 5 complete (2026-07-10)
+**Last updated**: PR 6 complete (2026-07-11)
 **Maintainer**: Update this document after each PR to track component status.

--- a/src/components/CancelTransactions/CancelConfirmModal.jsx
+++ b/src/components/CancelTransactions/CancelConfirmModal.jsx
@@ -21,46 +21,46 @@ export default function CancelConfirmModal({ show, onClose, onConfirm, transacti
         <div className="space-y-6">
           {/* Warning Icon */}
           <div className="flex justify-center">
-            <div className="dark:bg-red-900/30 flex size-16 items-center justify-center rounded-full bg-red-100">
-              <FontAwesomeIcon icon={faExclamationTriangle} className="size-8 text-red-600 dark:text-red-400" />
+            <div className="flex size-16 items-center justify-center rounded-full bg-error-100 dark:bg-error-900">
+              <FontAwesomeIcon icon={faExclamationTriangle} className="size-8 text-error-600 dark:text-error-400" />
             </div>
           </div>
 
           {/* Title */}
           <div className="text-center">
-            <h3 className="text-xl font-bold text-slate-800 dark:text-white">¿Cancelar esta transacción?</h3>
-            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            <h3 className="text-xl font-bold text-neutral-800 dark:text-neutral-50">¿Cancelar esta transacción?</h3>
+            <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
               Esta acción es <span className="font-semibold">irreversible</span>. La transacción será marcada como cancelada.
             </p>
           </div>
 
           {/* Transaction Details */}
-          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-slate-600 dark:bg-slate-700">
-            <h4 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-300">Detalles de la transacción</h4>
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-600 dark:bg-neutral-700">
+            <h4 className="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-300">Detalles de la transacción</h4>
             <div className="grid grid-cols-2 gap-3 text-sm">
               <div>
-                <p className="text-slate-500 dark:text-slate-400">ID Factura</p>
-                <p className="font-medium text-slate-900 dark:text-white">{transaction.invoice?.id?.slice(0, 8) || 'N/A'}</p>
+                <p className="text-neutral-500 dark:text-neutral-400">ID Factura</p>
+                <p className="font-medium text-neutral-900 dark:text-neutral-50">{transaction.invoice?.id?.slice(0, 8) || 'N/A'}</p>
               </div>
               <div>
-                <p className="text-slate-500 dark:text-slate-400">Fecha</p>
-                <p className="font-medium text-slate-900 dark:text-white">{transaction.created_at ? formatDate(transaction.created_at) : 'N/A'}</p>
+                <p className="text-neutral-500 dark:text-neutral-400">Fecha</p>
+                <p className="font-medium text-neutral-900 dark:text-neutral-50">{transaction.created_at ? formatDate(transaction.created_at) : 'N/A'}</p>
               </div>
               <div>
-                <p className="text-slate-500 dark:text-slate-400">Tipo</p>
-                <p className="font-medium text-slate-900 dark:text-white">{transaction.transaction_type?.description || 'N/A'}</p>
+                <p className="text-neutral-500 dark:text-neutral-400">Tipo</p>
+                <p className="font-medium text-neutral-900 dark:text-neutral-50">{transaction.transaction_type?.description || 'N/A'}</p>
               </div>
               <div>
-                <p className="text-slate-500 dark:text-slate-400">Método de pago</p>
-                <p className="font-medium text-slate-900 dark:text-white">{transaction.payment_method?.description || 'N/A'}</p>
+                <p className="text-neutral-500 dark:text-neutral-400">Método de pago</p>
+                <p className="font-medium text-neutral-900 dark:text-neutral-50">{transaction.payment_method?.description || 'N/A'}</p>
               </div>
               <div className="col-span-2">
-                <p className="text-slate-500 dark:text-slate-400">Descripción</p>
-                <p className="font-medium text-slate-900 dark:text-white">{transaction.description || 'Sin descripción'}</p>
+                <p className="text-neutral-500 dark:text-neutral-400">Descripción</p>
+                <p className="font-medium text-neutral-900 dark:text-neutral-50">{transaction.description || 'Sin descripción'}</p>
               </div>
-              <div className="col-span-2 border-t border-gray-300 pt-3 dark:border-slate-600">
-                <p className="text-slate-500 dark:text-slate-400">Monto total</p>
-                <p className="text-xl font-bold text-red-600 dark:text-red-400">{formatCurrency(transaction.amount)}</p>
+              <div className="col-span-2 border-t border-neutral-300 pt-3 dark:border-neutral-600">
+                <p className="text-neutral-500 dark:text-neutral-400">Monto total</p>
+                <p className="text-xl font-bold text-error-600 dark:text-error-400">{formatCurrency(transaction.amount)}</p>
               </div>
             </div>
           </div>

--- a/src/components/CancelTransactions/DevolutionConfirmModal.jsx
+++ b/src/components/CancelTransactions/DevolutionConfirmModal.jsx
@@ -21,53 +21,53 @@ export default function DevolutionConfirmModal({ show, onClose, onConfirm, trans
         <div className="space-y-6">
           {/* Warning Icon */}
           <div className="flex justify-center">
-            <div className="dark:bg-yellow-900/30 flex size-16 items-center justify-center rounded-full bg-yellow-100">
-              <FontAwesomeIcon icon={faUndo} className="size-8 text-yellow-600 dark:text-yellow-400" />
+            <div className="flex size-16 items-center justify-center rounded-full bg-warning-100 dark:bg-warning-900">
+              <FontAwesomeIcon icon={faUndo} className="size-8 text-warning-600 dark:text-warning-400" />
             </div>
           </div>
 
           {/* Title */}
           <div className="text-center">
-            <h3 className="text-xl font-bold text-slate-800 dark:text-white">¿Realizar devolución?</h3>
-            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            <h3 className="text-xl font-bold text-neutral-800 dark:text-neutral-50">¿Realizar devolución?</h3>
+            <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
               Se realizará la devolución de esta transacción. El monto será devuelto al cliente.
             </p>
           </div>
 
           {/* Transaction Details */}
-          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-slate-600 dark:bg-slate-700">
-            <h4 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-300">Detalles de la transacción</h4>
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-600 dark:bg-neutral-700">
+            <h4 className="mb-3 text-sm font-semibold text-neutral-700 dark:text-neutral-300">Detalles de la transacción</h4>
             <div className="grid grid-cols-2 gap-3 text-sm">
               <div>
-                <p className="text-slate-500 dark:text-slate-400">ID Factura</p>
-                <p className="font-medium text-slate-900 dark:text-white">{transaction.invoice?.id?.slice(0, 8) || 'N/A'}</p>
+                <p className="text-neutral-500 dark:text-neutral-400">ID Factura</p>
+                <p className="font-medium text-neutral-900 dark:text-neutral-50">{transaction.invoice?.id?.slice(0, 8) || 'N/A'}</p>
               </div>
               <div>
-                <p className="text-slate-500 dark:text-slate-400">Fecha</p>
-                <p className="font-medium text-slate-900 dark:text-white">{transaction.created_at ? formatDate(transaction.created_at) : 'N/A'}</p>
+                <p className="text-neutral-500 dark:text-neutral-400">Fecha</p>
+                <p className="font-medium text-neutral-900 dark:text-neutral-50">{transaction.created_at ? formatDate(transaction.created_at) : 'N/A'}</p>
               </div>
               <div>
-                <p className="text-slate-500 dark:text-slate-400">Tipo</p>
-                <p className="font-medium text-slate-900 dark:text-white">{transaction.transaction_type?.description || 'N/A'}</p>
+                <p className="text-neutral-500 dark:text-neutral-400">Tipo</p>
+                <p className="font-medium text-neutral-900 dark:text-neutral-50">{transaction.transaction_type?.description || 'N/A'}</p>
               </div>
               <div>
-                <p className="text-slate-500 dark:text-slate-400">Método de pago</p>
-                <p className="font-medium text-slate-900 dark:text-white">{transaction.payment_method?.description || 'N/A'}</p>
+                <p className="text-neutral-500 dark:text-neutral-400">Método de pago</p>
+                <p className="font-medium text-neutral-900 dark:text-neutral-50">{transaction.payment_method?.description || 'N/A'}</p>
               </div>
               <div className="col-span-2">
-                <p className="text-slate-500 dark:text-slate-400">Descripción</p>
-                <p className="font-medium text-slate-900 dark:text-white">{transaction.description || 'Sin descripción'}</p>
+                <p className="text-neutral-500 dark:text-neutral-400">Descripción</p>
+                <p className="font-medium text-neutral-900 dark:text-neutral-50">{transaction.description || 'Sin descripción'}</p>
               </div>
-              <div className="col-span-2 border-t border-gray-300 pt-3 dark:border-slate-600">
-                <p className="text-slate-500 dark:text-slate-400">Monto a devolver</p>
-                <p className="text-xl font-bold text-yellow-600 dark:text-yellow-400">{formatCurrency(transaction.amount)}</p>
+              <div className="col-span-2 border-t border-neutral-300 pt-3 dark:border-neutral-600">
+                <p className="text-neutral-500 dark:text-neutral-400">Monto a devolver</p>
+                <p className="text-xl font-bold text-warning-600 dark:text-warning-400">{formatCurrency(transaction.amount)}</p>
               </div>
             </div>
           </div>
 
           {/* Info Box */}
-          <div className="dark:bg-yellow-900/20 rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-800">
-            <p className="text-sm text-yellow-800 dark:text-yellow-400">
+          <div className="rounded-lg border border-warning-200 bg-warning-50 p-4 dark:border-warning-800 dark:bg-warning-900">
+            <p className="text-sm text-warning-800 dark:text-warning-400">
               <span className="font-semibold">Nota:</span> Esta acción generará un registro de devolución 
               y actualizará el estado de la transacción.
             </p>

--- a/src/components/CloseRegister/AmountInputCard.jsx
+++ b/src/components/CloseRegister/AmountInputCard.jsx
@@ -55,10 +55,10 @@ export default function AmountInputCard({
   return (
     <div className="space-y-4">
       <div>
-        <h2 className="text-base font-semibold text-gray-800 dark:text-white">
+        <h2 className="text-base font-semibold text-neutral-800 dark:text-neutral-50">
           Ingrese los montos contados
         </h2>
-        <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mt-0.5 text-sm text-neutral-500 dark:text-neutral-400">
           Ingrese el dinero físico y vouchers contados al cerrar la caja.
         </p>
       </div>
@@ -78,7 +78,7 @@ export default function AmountInputCard({
             <div key={method.id}>
               <label
                 htmlFor={inputId}
-                className="mb-1.5 flex items-center gap-1.5 text-sm font-medium text-gray-700 dark:text-gray-300"
+                className="mb-1.5 flex items-center gap-1.5 text-sm font-medium text-neutral-700 dark:text-neutral-300"
               >
                 <FontAwesomeIcon icon={icon} className={color} aria-hidden="true" />
                 {desc}
@@ -99,7 +99,8 @@ export default function AmountInputCard({
               {fieldError && (
                 <p
                   id={`${inputId}-error`}
-                  className="mx-1 mt-1 text-left text-sm text-red-500"
+                  className="mx-1 mt-1 text-left text-sm text-error-500"
+                  role="alert"
                 >
                   {fieldError.message}
                 </p>
@@ -108,8 +109,8 @@ export default function AmountInputCard({
                 <p
                   className={`mt-1 text-xs ${
                     diff === 0
-                      ? 'text-gray-500 dark:text-gray-400'
-                      : 'font-medium text-red-600 dark:text-red-400'
+                      ? 'text-neutral-500 dark:text-neutral-400'
+                      : 'font-medium text-error-600 dark:text-error-400'
                   }`}
                 >
                   Esperado: {formatCurrency(expected)}
@@ -130,7 +131,7 @@ export default function AmountInputCard({
       <div>
         <label
           htmlFor="close-notes"
-          className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300"
+          className="mb-1.5 block text-sm font-medium text-neutral-700 dark:text-neutral-300"
         >
           Notas <span className="font-normal text-neutral-400">(Opcional)</span>
         </label>
@@ -146,7 +147,7 @@ export default function AmountInputCard({
           {...register('notes')}
         />
         {errors?.notes && (
-          <p id="close-notes-error" className="mx-1 mt-1 text-left text-sm text-red-500">
+          <p id="close-notes-error" className="mx-1 mt-1 text-left text-sm text-error-500" role="alert">
             {errors.notes.message}
           </p>
         )}

--- a/src/components/CloseRegister/ApprovalModal.jsx
+++ b/src/components/CloseRegister/ApprovalModal.jsx
@@ -48,24 +48,24 @@ export default function ApprovalModal({
             <span className="font-medium">¡Cierre enviado a revisión!</span> El cierre de caja se ha registrado correctamente.
           </Alert>
 
-          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-slate-600 dark:bg-slate-700">
-            <h3 className="mb-3 font-semibold text-gray-800 dark:text-white">Resumen del Cierre</h3>
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-600 dark:bg-neutral-700">
+            <h3 className="mb-3 font-semibold text-neutral-800 dark:text-neutral-50">Resumen del Cierre</h3>
 
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
-                <span className="text-gray-600 dark:text-gray-400">Monto Inicial:</span>
-                <span className="font-medium text-gray-800 dark:text-white">
+                <span className="text-neutral-600 dark:text-neutral-400">Monto Inicial:</span>
+                <span className="font-medium text-neutral-800 dark:text-neutral-50">
                   {formatCurrency(calculationData?.initialAmount || 0)}
                 </span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-600 dark:text-gray-400">Total Transacciones:</span>
-                <span className="font-medium text-gray-800 dark:text-white">
+                <span className="text-neutral-600 dark:text-neutral-400">Total Transacciones:</span>
+                <span className="font-medium text-neutral-800 dark:text-neutral-50">
                   {formatCurrency(calculationData?.totalAmount || 0)}
                 </span>
               </div>
-              <div className="flex justify-between border-t pt-2 dark:border-slate-600">
-                <span className="text-gray-600 dark:text-gray-400">Balance Final:</span>
+              <div className="flex justify-between border-t pt-2 dark:border-neutral-600">
+                <span className="text-neutral-600 dark:text-neutral-400">Balance Final:</span>
                 <span className="font-semibold text-primary-700 dark:text-primary-400">
                   {formatCurrency((calculationData?.initialAmount || 0) + totalEntered)}
                 </span>
@@ -74,15 +74,15 @@ export default function ApprovalModal({
 
             {/* Montos ingresados por método — dinámico */}
             {paymentMethods.length > 0 && (
-              <div className="mt-4 border-t pt-3 dark:border-slate-600">
-                <p className="mb-2 text-xs font-medium text-gray-700 dark:text-gray-300">
+              <div className="mt-4 border-t pt-3 dark:border-neutral-600">
+                <p className="mb-2 text-xs font-medium text-neutral-700 dark:text-neutral-300">
                   Montos Ingresados:
                 </p>
                 <div className={`grid gap-2 text-sm ${colClass}`}>
                   {paymentMethods.map((method) => (
                     <div key={method.id} className="text-center">
-                      <p className="text-xs text-gray-600 dark:text-gray-400">{method.description}</p>
-                      <p className="font-medium text-gray-800 dark:text-white">
+                      <p className="text-xs text-neutral-600 dark:text-neutral-400">{method.description}</p>
+                      <p className="font-medium text-neutral-800 dark:text-neutral-50">
                         {formatCurrency(enteredAmounts[method.description] ?? 0)}
                       </p>
                     </div>
@@ -92,8 +92,8 @@ export default function ApprovalModal({
             )}
 
             {hasDiscrepancies && (
-              <div className="dark:bg-yellow-900/20 mt-3 rounded bg-yellow-50 p-2">
-                <p className="flex items-center gap-1 text-xs text-yellow-800 dark:text-yellow-400">
+              <div className="mt-3 rounded bg-warning-100 p-2 dark:bg-warning-900">
+                <p className="flex items-center gap-1 text-xs text-warning-800 dark:text-warning-400">
                   <FontAwesomeIcon icon={faExclamationTriangle} aria-hidden="true" />
                   Nota: Se detectaron diferencias de {formatCurrency(differences?.total || 0)}
                 </p>
@@ -101,7 +101,7 @@ export default function ApprovalModal({
             )}
           </div>
 
-          <div className="dark:bg-secondary-900/20 rounded-lg bg-secondary-50 p-4">
+          <div className="rounded-lg bg-secondary-100 p-4 dark:bg-secondary-900">
             <p className="text-sm text-secondary-800 dark:text-secondary-200">
               <span className="font-medium">¿Desea aprobar este cierre?</span>
               <br />

--- a/src/components/CloseRegister/ReconciliationSummaryCard.jsx
+++ b/src/components/CloseRegister/ReconciliationSummaryCard.jsx
@@ -25,46 +25,46 @@ export default function ReconciliationSummaryCard({
     <div className="space-y-4">
       {/* Tiles de resumen general */}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <div className="dark:bg-secondary-900/20 rounded-lg bg-secondary-50 p-3">
-          <p className="text-xs text-gray-500 dark:text-gray-400">Monto Inicial</p>
+        <div className="rounded-lg bg-secondary-100 p-3 dark:bg-secondary-900">
+          <p className="text-xs text-neutral-500 dark:text-neutral-400">Monto Inicial</p>
           <p className="mt-0.5 text-xl font-bold text-secondary-700 dark:text-secondary-400">
             {formatCurrency(calculationData.initialAmount)}
           </p>
         </div>
-        <div className="dark:bg-primary-900/20 rounded-lg bg-primary-50 p-3">
-          <p className="text-xs text-gray-500 dark:text-gray-400">Total Transacciones</p>
+        <div className="rounded-lg bg-primary-100 p-3 dark:bg-primary-900">
+          <p className="text-xs text-neutral-500 dark:text-neutral-400">Total Transacciones</p>
           <p className="mt-0.5 text-xl font-bold text-primary-700 dark:text-primary-400">
             {formatCurrency(calculationData.totalAmount)}
           </p>
         </div>
-        <div className="dark:bg-purple-900/20 rounded-lg bg-purple-50 p-3">
-          <p className="text-xs text-gray-500 dark:text-gray-400">Balance Esperado</p>
-          <p className="mt-0.5 text-xl font-bold text-purple-700 dark:text-purple-400">
+        <div className="rounded-lg bg-info-100 p-3 dark:bg-info-900">
+          <p className="text-xs text-neutral-500 dark:text-neutral-400">Balance Esperado</p>
+          <p className="mt-0.5 text-xl font-bold text-info-700 dark:text-info-400">
             {formatCurrency(calculationData.expectedBalance)}
           </p>
         </div>
       </div>
 
       {/* Tabla comparativa dinámica */}
-      <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-slate-600">
+      <div className="overflow-x-auto rounded-lg border border-neutral-200 dark:border-neutral-600">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-gray-200 bg-gray-50 dark:border-slate-600 dark:bg-slate-700">
-              <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            <tr className="border-b border-neutral-200 bg-neutral-50 dark:border-neutral-600 dark:bg-neutral-700">
+              <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
                 Método de Pago
               </th>
-              <th className="px-4 py-2.5 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              <th className="px-4 py-2.5 text-right text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
                 Esperado
               </th>
-              <th className="px-4 py-2.5 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              <th className="px-4 py-2.5 text-right text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
                 Ingresado
               </th>
-              <th className="px-4 py-2.5 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              <th className="px-4 py-2.5 text-right text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
                 Diferencia
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100 bg-white dark:divide-slate-700 dark:bg-slate-800">
+          <tbody className="divide-y divide-neutral-100 bg-white dark:divide-neutral-700 dark:bg-neutral-800">
             {paymentMethods.map((method) => {
               const desc = method.description;
               const methodDiff = differences?.byMethod?.[desc];
@@ -74,14 +74,14 @@ export default function ReconciliationSummaryCard({
               const diffColor =
                 diff === 0
                   ? 'text-primary-600 dark:text-primary-400'
-                  : 'font-medium text-red-600 dark:text-red-400';
+                  : 'font-medium text-error-600 dark:text-error-400';
               return (
-                <tr key={method.id} className="dark:hover:bg-slate-700/50 transition-colors hover:bg-gray-50">
-                  <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{desc}</td>
-                  <td className="px-4 py-3 text-right text-gray-600 dark:text-gray-400">
+                <tr key={method.id} className="transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-700">
+                  <td className="px-4 py-3 text-neutral-700 dark:text-neutral-300">{desc}</td>
+                  <td className="px-4 py-3 text-right text-neutral-600 dark:text-neutral-400">
                     {formatCurrency(expected)}
                   </td>
-                  <td className="px-4 py-3 text-right text-gray-800 dark:text-white">
+                  <td className="px-4 py-3 text-right text-neutral-800 dark:text-neutral-50">
                     {formatCurrency(entered)}
                   </td>
                   <td className={`px-4 py-3 text-right ${diffColor}`}>
@@ -92,19 +92,19 @@ export default function ReconciliationSummaryCard({
             })}
           </tbody>
           <tfoot>
-            <tr className="border-t-2 border-gray-300 bg-gray-50 dark:border-slate-500 dark:bg-slate-700">
-              <td className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
+            <tr className="border-t-2 border-neutral-300 bg-neutral-50 dark:border-neutral-500 dark:bg-neutral-700">
+              <td className="px-4 py-3 text-sm font-semibold text-neutral-700 dark:text-neutral-300">
                 Total
               </td>
-              <td className="px-4 py-3 text-right text-sm font-semibold text-gray-700 dark:text-gray-300">
+              <td className="px-4 py-3 text-right text-sm font-semibold text-neutral-700 dark:text-neutral-300">
                 {formatCurrency(differences?.totalExpected ?? calculationData.totalAmount)}
               </td>
-              <td className="px-4 py-3 text-right text-sm font-semibold text-gray-800 dark:text-white">
+              <td className="px-4 py-3 text-right text-sm font-semibold text-neutral-800 dark:text-neutral-50">
                 {formatCurrency(totalEntered)}
               </td>
               <td className={`px-4 py-3 text-right text-sm font-semibold ${
                 hasDiscrepancies
-                  ? 'text-red-600 dark:text-red-400'
+                  ? 'text-error-600 dark:text-error-400'
                   : 'text-primary-600 dark:text-primary-400'
               }`}>
                 {(differences?.total ?? 0) > 0 ? '+' : ''}

--- a/src/components/Reports/ReportFilters.jsx
+++ b/src/components/Reports/ReportFilters.jsx
@@ -43,7 +43,7 @@ const ReportFilters = ({ reportType = '', professionals = [], previsions = [], l
   };
 
   return (
-    <form onSubmit={handleSubmit} className="dark:bg-slate-700/40 flex flex-wrap items-end gap-4 rounded-lg bg-gray-50 p-4">
+    <form onSubmit={handleSubmit} className="flex flex-wrap items-end gap-4 rounded-lg bg-neutral-50 p-4 dark:bg-neutral-700">
       {/* Fecha inicio */}
       <div className="min-w-[140px]">
         <Label htmlFor="startDate" value="Fecha inicio" className="mb-1 block text-sm" />
@@ -54,7 +54,7 @@ const ReportFilters = ({ reportType = '', professionals = [], previsions = [], l
           max={endDate}
           onChange={(e) => setStartDate(e.target.value)}
           required
-          className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+          className="block w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 focus:border-primary-500 focus:ring-primary-500 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-50"
         />
       </div>
 
@@ -68,7 +68,7 @@ const ReportFilters = ({ reportType = '', professionals = [], previsions = [], l
           min={startDate}
           onChange={(e) => setEndDate(e.target.value)}
           required
-          className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-800 dark:text-white"
+          className="block w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 focus:border-primary-500 focus:ring-primary-500 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-50"
         />
       </div>
 
@@ -129,7 +129,7 @@ const ReportFilters = ({ reportType = '', professionals = [], previsions = [], l
 
       {/* Error de validación */}
       {validationError && (
-        <p className="w-full text-sm text-red-600 dark:text-red-400" role="alert">
+        <p className="w-full text-sm text-error-600 dark:text-error-400" role="alert">
           {validationError}
         </p>
       )}

--- a/src/components/Reports/ReportViewer.jsx
+++ b/src/components/Reports/ReportViewer.jsx
@@ -46,7 +46,7 @@ const ReportViewer = ({ blob, filename, error }) => {
     <div className="mt-4 space-y-3">
       {/* Barra de acciones */}
       <div className="flex items-center justify-between">
-        <p className="text-sm text-gray-500 dark:text-gray-400">
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
           Vista previa del reporte generado
         </p>
         <Button color="success" size="sm" onClick={handleDownload}>
@@ -59,7 +59,7 @@ const ReportViewer = ({ blob, filename, error }) => {
       <iframe
         src={objectUrl}
         title="Reporte PDF"
-        className="h-[600px] w-full rounded-lg border border-gray-200 dark:border-slate-600"
+        className="h-[600px] w-full rounded-lg border border-neutral-200 dark:border-neutral-600"
         aria-label="Vista previa del reporte en PDF"
       />
     </div>

--- a/src/pages/dashboard/CancelTransactions.jsx
+++ b/src/pages/dashboard/CancelTransactions.jsx
@@ -15,9 +15,9 @@ const CancelTransactions = () => {
   const c = useCancelTransactions();
 
   return (
-    <section className="min-h-screen bg-gray-50 dark:bg-slate-900">
+    <section className="min-h-screen bg-neutral-50 dark:bg-neutral-900">
       <div className="container mx-auto max-w-6xl px-4 py-6">
-        <Card className="border border-gray-200 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-800">
+        <Card className="border border-neutral-200 bg-white p-6 shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
           <CancelHeader />
 
           {c.alert.show && (

--- a/src/pages/dashboard/CloseRegister.jsx
+++ b/src/pages/dashboard/CloseRegister.jsx
@@ -18,11 +18,11 @@ const CloseRegister = () => {
 
   if (c.loading && !c.showNoRegisterModal) {
     return (
-      <section className="min-h-screen bg-gray-50 dark:bg-slate-900">
+      <section className="min-h-screen bg-neutral-50 dark:bg-neutral-900">
         <div className="container mx-auto max-w-4xl px-4 py-6">
           <Card className="flex items-center justify-center p-12">
             <Spinner size="xl" />
-            <p className="mt-4 text-gray-600 dark:text-gray-400">
+            <p className="mt-4 text-neutral-600 dark:text-neutral-400">
               Cargando información de cuadratura...
             </p>
           </Card>
@@ -32,9 +32,9 @@ const CloseRegister = () => {
   }
 
   return (
-    <section className="min-h-screen bg-gray-50 dark:bg-slate-900">
+    <section className="min-h-screen bg-neutral-50 dark:bg-neutral-900">
       <div className="container mx-auto max-w-4xl px-4 py-6">
-        <Card className="border border-gray-200 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-800">
+        <Card className="border border-neutral-200 bg-white p-6 shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
           <CloseHeader />
 
           {c.error && (

--- a/src/pages/dashboard/Reports.jsx
+++ b/src/pages/dashboard/Reports.jsx
@@ -21,9 +21,9 @@ const Reports = () => {
   const r = useReports();
 
   return (
-    <section className="min-h-screen bg-gray-50 dark:bg-slate-900">
+    <section className="min-h-screen bg-neutral-50 dark:bg-neutral-900">
       <div className="container mx-auto max-w-5xl px-4 py-6">
-        <Card className="border border-gray-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-800">
+        <Card className="border border-neutral-200 bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
           <Breadcrumb className="mb-4">
             <Breadcrumb.Item
               href="/dashboard"
@@ -32,7 +32,7 @@ const Reports = () => {
             >
               Inicio
             </Breadcrumb.Item>
-            <Breadcrumb.Item className="text-gray-600 dark:text-gray-400">
+            <Breadcrumb.Item className="text-neutral-600 dark:text-neutral-400">
               Reportes
             </Breadcrumb.Item>
           </Breadcrumb>
@@ -44,9 +44,9 @@ const Reports = () => {
                 className="text-2xl text-primary-600 dark:text-primary-400"
                 aria-hidden="true"
               />
-              <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Reportes</h1>
+              <h1 className="text-2xl font-bold text-neutral-800 dark:text-neutral-50">Reportes</h1>
             </div>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
               Genera y descarga reportes del sistema filtrados por fecha.
             </p>
           </div>
@@ -59,7 +59,7 @@ const Reports = () => {
               )}
             >
               <div className="py-4">
-                <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
+                <p className="mb-4 text-sm text-neutral-600 dark:text-neutral-400">
                   Listado de transacciones completadas en el período seleccionado.
                 </p>
                 <ReportFilters reportType="daily-sales" loading={r.loadingDaily} onGenerate={r.handleDailySales} />
@@ -74,7 +74,7 @@ const Reports = () => {
               )}
             >
               <div className="py-4">
-                <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
+                <p className="mb-4 text-sm text-neutral-600 dark:text-neutral-400">
                   Historial de cuadraturas y cierres de caja en el período seleccionado.
                 </p>
                 <ReportFilters reportType="reconciliations" loading={r.loadingRecon} onGenerate={r.handleReconciliations} />
@@ -89,7 +89,7 @@ const Reports = () => {
               )}
             >
               <div className="py-4">
-                <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
+                <p className="mb-4 text-sm text-neutral-600 dark:text-neutral-400">
                   Atenciones y montos agrupados por profesional en el período seleccionado.
                 </p>
                 <ReportFilters
@@ -109,7 +109,7 @@ const Reports = () => {
               )}
             >
               <div className="py-4">
-                <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
+                <p className="mb-4 text-sm text-neutral-600 dark:text-neutral-400">
                   Atenciones y montos agrupados por previsión de salud en el período seleccionado.
                 </p>
                 <ReportFilters

--- a/src/pages/dashboard/cancel/CancelFilters.jsx
+++ b/src/pages/dashboard/cancel/CancelFilters.jsx
@@ -18,7 +18,7 @@ export const CancelFilters = ({
           icon={() => (
             <FontAwesomeIcon
               icon={faSearch}
-              className="size-4 text-gray-400"
+              className="size-4 text-neutral-400"
               aria-hidden="true"
             />
           )}
@@ -38,9 +38,9 @@ export const CancelFilters = ({
         </Button>
       </div>
 
-      <div className="mb-4 flex items-center justify-end gap-2 text-sm text-gray-500 dark:text-gray-400">
+      <div className="mb-4 flex items-center justify-end gap-2 text-sm text-neutral-500 dark:text-neutral-400">
         <span>Total de movimientos:</span>
-        <span className="font-semibold text-gray-800 dark:text-white">
+        <span className="font-semibold text-neutral-800 dark:text-neutral-50">
           {totalItems}
         </span>
       </div>

--- a/src/pages/dashboard/cancel/CancelHeader.jsx
+++ b/src/pages/dashboard/cancel/CancelHeader.jsx
@@ -14,7 +14,7 @@ export const CancelHeader = () => {
         >
           Inicio
         </Breadcrumb.Item>
-        <Breadcrumb.Item className="text-gray-600 dark:text-gray-400">
+        <Breadcrumb.Item className="text-neutral-600 dark:text-neutral-400">
           Anulación de Movimientos
         </Breadcrumb.Item>
       </Breadcrumb>
@@ -26,11 +26,11 @@ export const CancelHeader = () => {
             className="text-2xl text-primary-600 dark:text-primary-400"
             aria-hidden="true"
           />
-          <h1 className="text-2xl font-bold text-gray-800 dark:text-white">
+          <h1 className="text-2xl font-bold text-neutral-800 dark:text-neutral-50">
             Anulación de Movimientos
           </h1>
         </div>
-        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
           Gestiona cancelaciones y devoluciones de las transacciones de la caja
           actual.
         </p>

--- a/src/pages/dashboard/cancel/CancelList.jsx
+++ b/src/pages/dashboard/cancel/CancelList.jsx
@@ -43,7 +43,7 @@ export const CancelList = ({
     return (
       <div className="flex items-center justify-center py-16">
         <Spinner size="xl" aria-label="Cargando transacciones" />
-        <span className="ml-3 text-lg text-slate-600 dark:text-slate-400">
+        <span className="ml-3 text-lg text-neutral-600 dark:text-neutral-400">
           Cargando transacciones...
         </span>
       </div>
@@ -55,13 +55,13 @@ export const CancelList = ({
       <div className="py-16 text-center">
         <FontAwesomeIcon
           icon={faExclamationTriangle}
-          className="mb-4 size-12 text-gray-400 dark:text-gray-500"
+          className="mb-4 size-12 text-neutral-400 dark:text-neutral-500"
           aria-hidden="true"
         />
-        <p className="text-lg text-slate-600 dark:text-slate-400">
+        <p className="text-lg text-neutral-600 dark:text-neutral-400">
           No se encontraron transacciones
         </p>
-        <p className="text-sm text-slate-400 dark:text-slate-500">
+        <p className="text-sm text-neutral-400 dark:text-neutral-500">
           Intenta con otros términos de búsqueda
         </p>
       </div>
@@ -88,26 +88,26 @@ export const CancelList = ({
             {transactions.map((transaction) => (
               <Table.Row
                 key={transaction.id}
-                className="bg-white dark:border-slate-700 dark:bg-slate-800"
+                className="bg-white dark:border-neutral-700 dark:bg-neutral-800"
               >
-                <Table.Cell className="font-medium text-slate-900 dark:text-white">
+                <Table.Cell className="font-medium text-neutral-900 dark:text-neutral-50">
                   {transaction.invoice?.id?.slice(0, 8) ?? 'N/A'}
                 </Table.Cell>
-                <Table.Cell className="whitespace-nowrap text-sm text-slate-600 dark:text-slate-400">
+                <Table.Cell className="whitespace-nowrap text-sm text-neutral-600 dark:text-neutral-400">
                   {transaction.created_at
                     ? formatDate(transaction.created_at)
                     : 'N/A'}
                 </Table.Cell>
-                <Table.Cell className="max-w-xs truncate text-slate-600 dark:text-slate-400">
+                <Table.Cell className="max-w-xs truncate text-neutral-600 dark:text-neutral-400">
                   {transaction.description ?? 'Sin descripción'}
                 </Table.Cell>
-                <Table.Cell className="text-slate-600 dark:text-slate-400">
+                <Table.Cell className="text-neutral-600 dark:text-neutral-400">
                   {transaction.transaction_type?.description ?? 'N/A'}
                 </Table.Cell>
-                <Table.Cell className="text-slate-600 dark:text-slate-400">
+                <Table.Cell className="text-neutral-600 dark:text-neutral-400">
                   {transaction.payment_method?.description ?? 'N/A'}
                 </Table.Cell>
-                <Table.Cell className="whitespace-nowrap font-semibold text-slate-900 dark:text-white">
+                <Table.Cell className="whitespace-nowrap font-semibold text-neutral-900 dark:text-neutral-50">
                   {formatCurrency(transaction.amount)}
                 </Table.Cell>
                 <Table.Cell>{getStatusBadge(transaction.status)}</Table.Cell>

--- a/src/pages/dashboard/close/CloseHeader.jsx
+++ b/src/pages/dashboard/close/CloseHeader.jsx
@@ -16,7 +16,7 @@ const CloseHeader = () => (
       >
         Inicio
       </Breadcrumb.Item>
-      <Breadcrumb.Item className="text-gray-600">
+      <Breadcrumb.Item className="text-neutral-600 dark:text-neutral-400">
         Cuadratura y Cierre de Caja
       </Breadcrumb.Item>
     </Breadcrumb>
@@ -28,11 +28,11 @@ const CloseHeader = () => (
           className="text-2xl text-primary-600 dark:text-primary-400"
           aria-hidden="true"
         />
-        <h1 className="text-2xl font-bold text-gray-800 dark:text-white">
+        <h1 className="text-2xl font-bold text-neutral-800 dark:text-neutral-50">
           Cuadratura y Cierre de Caja
         </h1>
       </div>
-      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+      <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
         Verifica los montos y realiza el cierre diario de tu caja registradora.
       </p>
     </div>


### PR DESCRIPTION
## Summary

Visual restyle of Reports, CloseRegister, and CancelTransactions pages with semantic design tokens. Last visual batch before cross-cutting polish (PR 7).

## Linked Design

- Design: `sdd/ui-enterprise-redesign/design` (Engram #206)
- Spec D3: Reports & Admin Pages Redesign
- Tasks: T6-01..T6-04

## Changes

### T6-01: Reports restyle
- Reports.jsx: neutral bg/border/text tokens
- ReportFilters.jsx: neutral bg/border, error tokens, role="alert" on validation
- ReportViewer.jsx: neutral border/text tokens

### T6-02: CloseRegister restyle
- CloseRegister.jsx: neutral bg/border tokens
- CloseHeader.jsx: neutral text tokens
- ReconciliationSummaryCard.jsx: neutral/secondary/primary/info tokens, solid shades (no opacity modifiers)
- AmountInputCard.jsx: neutral/error tokens, role="alert" on field errors
- ApprovalModal.jsx: neutral/warning/secondary tokens, solid shades

### T6-03: CancelTransactions restyle
- CancelTransactions.jsx: neutral bg/border tokens
- CancelHeader.jsx: neutral text tokens
- CancelFilters.jsx: neutral text/icon tokens
- CancelList.jsx: neutral text/bg tokens
- CancelConfirmModal.jsx: neutral/error tokens, solid shades
- DevolutionConfirmModal.jsx: neutral/warning tokens, solid shades

### T6-04: Documentation
- COMPONENT_INVENTORY.md updated with PR 6 restyle status

## Token Mapping

| Raw | Semantic |
|-----|----------|
| `gray-*`/`slate-*` | `neutral-*` |
| `red-*` | `error-*` |
| `yellow-*` | `warning-*` |
| `purple-*` | `info-*` |
| Opacity modifiers (`/30`, `/50`) | Solid shades (`-100`, `-900`) |

## Verification

- [x] `pnpm lint --max-warnings 0`: pass
- [x] `pnpm build`: pass
- [x] Token audit: zero raw `bg-(gray|slate|zinc)-[0-9]` in restyled files
- [x] Token audit: zero raw `text-(gray|slate|zinc)-[0-9]` in restyled files
- [x] Token audit: zero opacity modifiers on CSS var colors
- [x] All files ≤200 lines (max: 174 — CancelList.jsx)
- [x] Dark mode parity: all components have `dark:` variants
- [x] Focus rings: visible on all interactive elements
- [x] A11y: `role="alert"` on error messages, `aria-invalid`/`aria-describedby` on inputs

## Review Focus

1. Token consistency — all colors should reference semantic tokens
2. Dark mode parity — toggle and verify each page
3. Solid shades — no opacity modifiers on CSS var colors (Tailwind limitation)
4. File sizes — all ≤200 lines

## Stacked PR Note

This PR targets `feature/EOD-0001-ui-enterprise-redesign-5` (PR 5). Merge order: PR 1 → 2A → 2B → 3 → 4 → 5 → **6** → 7.

## Budget

- Lines changed: ~325 (183 insertions + 142 deletions)
- Budget: 400 lines (tight, accepted)
- Files: 15 (14 JSX + 1 MD)

## Out of Scope

- Skeleton loading states (PR 7)
- Error boundaries (PR 7)
- Empty states (PR 7)
- Reduced-motion verification (PR 7)