### PR TITLE
fix(ui): Main.jsx restyle + opacity modifier cleanup (PR 7c — verify round 2 fixes)

### DIFF
--- a/src/components/Commons/NoRegisterModal.jsx
+++ b/src/components/Commons/NoRegisterModal.jsx
@@ -66,7 +66,7 @@ export default function NoRegisterModal({ show, context = 'sales' }) {
             </ul>
           </div>
 
-          <div className="dark:bg-secondary-900/20 rounded-lg bg-secondary-50 p-4">
+          <div className="rounded-lg bg-secondary-50 p-4 dark:bg-secondary-900">
             <p className="text-sm text-secondary-800 dark:text-secondary-200">
               <span className="font-medium">¿Desea abrir una caja ahora?</span>
               <br />

--- a/src/layout/nologin/HeaderNoLogin.jsx
+++ b/src/layout/nologin/HeaderNoLogin.jsx
@@ -12,7 +12,7 @@ export const HeaderNoLogin = ({ title }) => {
   return (
     <Navbar
       fluid
-      className="dark:bg-primary-950/95 sticky top-0 z-50 border-b border-neutral-200 bg-white/95 px-4 py-3 shadow-sm backdrop-blur-sm dark:border-primary-800 sm:px-6"
+      className="sticky top-0 z-50 border-b border-neutral-200 bg-white/95 px-4 py-3 shadow-sm backdrop-blur-sm dark:border-primary-800 dark:bg-primary-950 sm:px-6"
     >
       {/* Brand Section */}
       <Navbar.Brand as={Link} to="/" className="flex items-center space-x-3">

--- a/src/pages/dashboard/Main.jsx
+++ b/src/pages/dashboard/Main.jsx
@@ -44,18 +44,18 @@ const Main = () => {
     navigateTo(route)
   }
   return (
-    <section className="min-h-screen bg-gray-50 dark:bg-slate-900">
+    <section className="min-h-screen bg-neutral-50 dark:bg-neutral-900">
       <div className="container mx-auto max-w-7xl px-4 py-6">
-        <Card className="mx-2 mt-8 border border-gray-200 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-800">
+        <Card className="mx-2 mt-8 border border-neutral-200 bg-white p-6 shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
           <Breadcrumb>
             <Breadcrumb.Item href="#" icon={HiHome} className="text-primary-600 dark:text-primary-400">Inicio</Breadcrumb.Item>
-            <Breadcrumb.Item href="#" className="text-gray-600 dark:text-slate-400">Sistema POS</Breadcrumb.Item>
+            <Breadcrumb.Item href="#" className="text-neutral-600 dark:text-neutral-400">Sistema POS</Breadcrumb.Item>
           </Breadcrumb>
           <div className="mb-6 mt-4">
-            <h1 className="mb-2 text-3xl font-bold text-gray-800 dark:text-slate-100">
+            <h1 className="mb-2 text-3xl font-bold text-neutral-800 dark:text-neutral-100">
               Sistema de Caja Registradora
             </h1>
-            <p className="text-lg leading-relaxed text-gray-600 dark:text-slate-400">
+            <p className="text-lg leading-relaxed text-neutral-600 dark:text-neutral-400">
               Gestiona las finanzas de tu centro médico con todas las herramientas necesarias. 
               <span className="font-semibold text-secondary-700 dark:text-secondary-400">
                 {' '}Abre y cierra tu caja registradora, 
@@ -67,8 +67,12 @@ const Main = () => {
           { [...dashboardOptions].map((element, index) => (
             <Card 
               key={index}
-              className="cursor-pointer rounded-lg border border-gray-200 bg-white p-4 transition-all duration-200 hover:bg-gray-50 hover:shadow-lg dark:border-slate-700 dark:bg-slate-700 dark:hover:bg-slate-600"
+              className="cursor-pointer rounded-lg border border-neutral-200 bg-white p-4 transition-all duration-200 hover:bg-neutral-50 hover:shadow-lg dark:border-neutral-700 dark:bg-neutral-700 dark:hover:bg-neutral-600"
               onClick={() => goTo(element.link)}
+              role="button"
+              tabIndex={0}
+              aria-label={element.title}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goTo(element.link); } }}
             >
               <div className="flex items-center gap-6">
                 {/* Icono */}
@@ -79,16 +83,16 @@ const Main = () => {
                 
                 {/* Contenido */}
                 <div className="flex-1">
-                  <h5 className="mb-1 text-lg font-semibold text-gray-800 dark:text-slate-100">
+                  <h5 className="mb-1 text-lg font-semibold text-neutral-800 dark:text-neutral-100">
                     { element.title }
                   </h5>
-                  <p className="text-sm leading-relaxed text-gray-600 dark:text-slate-400">
+                  <p className="text-sm leading-relaxed text-neutral-600 dark:text-neutral-400">
                     { element.description }
                   </p>
                 </div>
 
                 {/* Indicador de acción */}
-                <div className="flex size-8 items-center justify-center rounded-full bg-gray-100 text-gray-500 dark:bg-slate-600 dark:text-slate-300">
+                <div className="flex size-8 items-center justify-center rounded-full bg-neutral-100 text-neutral-500 dark:bg-neutral-600 dark:text-neutral-300">
                   <HiChevronRight className="size-5" />
                 </div>
               </div>

--- a/src/pages/home/HomeFeatures.jsx
+++ b/src/pages/home/HomeFeatures.jsx
@@ -12,14 +12,14 @@ const COLOR_CLASSES = {
   primary: {
     bg: 'bg-primary-100',
     bgHover: 'group-hover:bg-primary-200',
-    bgDark: 'dark:bg-primary-900/40',
+    bgDark: 'dark:bg-primary-950',
     text: 'text-primary-600',
     textDark: 'dark:text-primary-400',
   },
   secondary: {
     bg: 'bg-secondary-100',
     bgHover: 'group-hover:bg-secondary-200',
-    bgDark: 'dark:bg-secondary-900/40',
+    bgDark: 'dark:bg-secondary-950',
     text: 'text-secondary-600',
     textDark: 'dark:text-secondary-400',
   },

--- a/src/pages/home/HomePricing.jsx
+++ b/src/pages/home/HomePricing.jsx
@@ -81,7 +81,7 @@ export const HomePricing = () => {
                 className={[
                   'relative flex flex-col rounded-2xl p-8',
                   highlight
-                    ? 'border-2 border-primary-500 bg-primary-50 shadow-xl dark:border-primary-400 dark:bg-primary-900/20'
+                    ? 'border-2 border-primary-500 bg-primary-50 shadow-xl dark:border-primary-400 dark:bg-primary-900'
                     : 'border border-gray-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-800',
                 ].join(' ')}
               >


### PR DESCRIPTION
## Summary

PR 7c fixes 2 issues found during re-verification after PR 7b.

## Fixes Applied

### Fix 1: Main.jsx visual restyle
- Replaced all 10 raw `gray-*`/`slate-*` tokens with `neutral-*` semantic equivalents
- Added a11y attributes on clickable dashboard cards (`role="button"`, `tabIndex`, `aria-label`, `onKeyDown`)

### Fix 2: Opacity modifier bug (HomeFeatures + HomePricing)
CSS var colors don't support Tailwind opacity modifiers (`/N`).
- `HomeFeatures.jsx`: `dark:bg-primary-900/40` → `dark:bg-primary-950`
- `HomeFeatures.jsx`: `dark:bg-secondary-900/40` → `dark:bg-secondary-950`
- `HomePricing.jsx`: `dark:bg-primary-900/20` → `dark:bg-primary-900`

### Fix 3: Full opacity audit
Searched entire `src/` for remaining `/N` modifiers on CSS var colors. Found and fixed 2 additional cases:
- `NoRegisterModal.jsx`: `dark:bg-secondary-900/20` → `dark:bg-secondary-900`
- `HeaderNoLogin.jsx`: `dark:bg-primary-950/95` → `dark:bg-primary-950`

## Commits
1. `fix(ui): restyle Main.jsx with semantic tokens (gray→neutral)`
2. `fix(opacity): replace /40 and /20 modifiers with solid shades`
3. `fix(opacity): audit and fix remaining /N modifiers on CSS var colors`

## Verification
- ✅ `pnpm lint --max-warnings 0`: PASS
- ✅ `pnpm build`: PASS (built in 7.35s)
- ✅ Token audit: 0 raw gray/slate in Main.jsx
- ✅ Opacity audit: 0 `/N` modifiers on CSS var colors in `src/`

## Chain Context
```
PR 1 → PR 2A → PR 2B → PR 3 → PR 4 → PR 5 → PR 6 → PR 7 → PR 7b → 📍 PR 7c
```
Stacked on PR 7b (`feature/EOD-0001-ui-enterprise-redesign-7b`).

## Linked
- Verify report (post-7b): flagged Main.jsx 10 raw tokens + 2 opacity modifier issues
- Related: PR 4/5/6 gotcha — Tailwind opacity modifiers do NOT work with CSS var colors