### PR TITLE
fix(security): OWASP ASVS L1 §8 remediation

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,13 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
+    # Security headers baseline (OWASP ASVS L1 - browser hardening)
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob:; connect-src 'self' https://api.caja.local http://api.caja.local; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
+
     # Assets con hash en el nombre → caché agresivo (Vite los versiona)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -21,6 +21,13 @@ const drainQueue = (error, token = null) => {
   failedQueue = [];
 };
 
+const redirectToLogin = () => {
+  if (typeof window === 'undefined') return;
+
+  const loginUrl = new URL('/login', window.location.origin);
+  window.location.replace(loginUrl.toString());
+};
+
 const axiosInstance = axios.create({
   baseURL: `${apiUrl}/api/v1/`,
   timeout: 8000,
@@ -90,7 +97,7 @@ axiosInstance.interceptors.response.use(
       useStore.getState().setAccessToken('');
       useStore.getState().setIsAuthenticated(false);
       useStore.getState().setUserInfo({});
-      window.location.href = '/login';
+      redirectToLogin();
 
       return Promise.reject(refreshError);
     } finally {

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -31,11 +31,36 @@ export const useStore = create(
       // Preferencia de modo oscuro — persiste en sessionStorage
       darkMode: false,
       setDarkMode: (darkMode) => set({ darkMode }),
-
     }),
     {
       name: 'allData',
       storage: createJSONStorage(() => sessionStorage),
-    }
-  )
+      version: 2,
+      // Persist only non-sensitive UI state. Auth/session data must remain in memory.
+      partialize: (state) => ({
+        formData: state.formData,
+        darkMode: state.darkMode,
+      }),
+      migrate: (persistedState = {}, version) => {
+        if (version < 2) {
+          // Whitelist: only non-sensitive UI state. Drops any legacy
+          // auth/session keys (accessToken, isAuthenticated, userInfo,
+          // openRegister) so they cannot leak across the v1 -> v2 upgrade.
+          return {
+            formData: persistedState.formData ?? {
+              forenames: '',
+              surnames: '',
+              nid: '',
+              email: '',
+              entity_id: '',
+              checkBox: false,
+            },
+            darkMode: persistedState.darkMode ?? false,
+          };
+        }
+
+        return persistedState;
+      },
+    },
+  ),
 );


### PR DESCRIPTION
## Summary

Applies the §8 remediation of the OWASP Top 10 + ASVS L1 audit (see `docs/security/OWASP_TOP10_ASVS_L1_AUDIT_2026-07-20.md`, section 8) — three pre-existing dirty-tree changes that close F-02, F-04, and F-05 on the frontend.

## Findings closed

- **F-02** (auth state persistence in sessionStorage, High) — `src/app/store.js`
  - `partialize` persists only `formData` and `darkMode`. Auth/session keys (`accessToken`, `isAuthenticated`, `userInfo`, `openRegister`) stay in memory only.
  - `version: 2` + whitelist `migrate` scrubs any legacy persisted auth/session keys on upgrade (v1 storage is overwritten with a non-sensitive whitelist on first hydration).
- **F-04** (missing security headers, Medium) — `nginx.conf`
  - Adds `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and `Permissions-Policy` baseline headers.
- **F-05** (open-redirect helper hardening, Low / accepted FP) — `src/api/axios.js`
  - Replaces `window.location.href = '/login'` with a same-origin `redirectToLogin()` helper using `URL` + `replace()` (no history entry for broken auth state, hard-coded path, no user-controlled input).

## Review

- `pnpm lint` → PASS
- `pnpm build` → PASS
- R1 (`review-risk`) sweep complete. Three findings raised — all WARNING/SUGGESTION (not merge-blocking):
  - **R1-001** HSTS not in nginx header set. Out of scope here: TLS is terminated at the Traefik edge; HSTS is expected to be set at the edge layer. Tracked as platform follow-up.
  - **R1-002** CSP `connect-src` allows `http://api.caja.local` (dev host). For production CSP the `http://` origin should be removed (env-conditional CSP or split server blocks). Out of scope for this PR; tracked as deployment-config follow-up.
  - **R1-003** Migration blacklist vs whitelist — **fixed in this commit**. `migrate` now uses a strict whitelist (`formData`, `darkMode`), eliminating the residual window where a legacy `accessToken` could survive in `sessionStorage` until first mutation.

## Related

- Audit: `docs/security/OWASP_TOP10_ASVS_L1_AUDIT_2026-07-20.md` (section 8)
- Findings registry: `docs/security/FINDINGS_REGISTRY.md`
- Staging runbook: `docs/security/STAGING_VALIDATION_RUNBOOK.md`
- Independent of #23/#24 and #22 (those are stacked residual-mitigation PRs and a P3 backend/edge issue respectively)